### PR TITLE
add the git url and git hash as labels to docker images

### DIFF
--- a/orbs/docker/orb.yml
+++ b/orbs/docker/orb.yml
@@ -43,6 +43,9 @@ commands:
           name: "Build the image."
           command: |
             docker build -t <<parameters.image_name>>:<<parameters.image_tag>> \
+                         -l org.opencontainers.image.vendor=JobTeaser
+                         -l org.opencontainers.image.url=https://github.com/jobteaser/$CIRCLE_PROJECT_REPONAME
+                         -l org.opencontainers.image.revision=$CIRCLE_SHA1
                          -f <<parameters.dockerfile_path>> \
                          .
 


### PR DESCRIPTION
Some websites suggest to use directly vcs-url and vcs-ref.
http://label-schema.org/rc1/ documents the org.label-schema. prefix, but
also says that it is deprecated in favour of OCI. OCI says
(https://github.com/opencontainers/image-spec/blob/master/annotations.md)
that we should use org.opencontainers.image.revision and
org.opencontainers.image.url. So OCI it is :)