### PR TITLE
chore: remove restriction on dev orbs publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,9 +54,6 @@ workflows:
       - validate
       - publish_dev:
           requires: ["validate"]
-          filters:
-            branches:
-              only: ["master"]
       - publish_stable:
           requires: ["validate"]
           filters:


### PR DESCRIPTION
There should be no issues on letting whatever branch to be published as dev orb.