### PR TITLE
update test job for rb-service orbs

### DIFF
--- a/orbs/rb-service/orb.yml
+++ b/orbs/rb-service/orb.yml
@@ -52,7 +52,7 @@ jobs:
       - run:
           name: "Run tests"
           command: |
-            bundle exec rake test
+            bundle exec rspec
       - save_ruby_bundle_cache
 
   build:


### PR DESCRIPTION
As in the V1 of rb-service rake has been removed we can't start the task
with rake anymore. As Rspec still comes with rb-serice I propose to
start the test with : bundle exec rspec