### PR TITLE
Change docker version used to 18.09.3  

### DIFF
--- a/orbs/docker/orb.yml
+++ b/orbs/docker/orb.yml
@@ -1,3 +1,4 @@
+---
 version: 2.1
 
 description: |
@@ -13,9 +14,11 @@ executors:
 
 commands:
   setup:
+    parameters:
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
+          version: "18.09.3"
 
   login:
     steps:


### PR DESCRIPTION
Sets the default docker version used to 18.09.3 which allows using buildkit
As discussed, we'd rather want most people to use the same docker version, to avoid chasing bugs in many docker versions. So I removed the `docker_version` parameter.

For future reference, if one really needs to use another docker version [1], inside your repository's `.circleci/config.yml`:

- (keep) import(ing) this orb;
- cut paste the `build_image` [job](https://circleci.com/docs/2.0/configuration-reference/#jobs), found in the docker orb, into your config file ;
- prefix the steps names in the job with `docker/` (to reference the orbs commands);
- "inline" the `setup` step and change the `version` value;
- If you were already calling `docker/build_image` in any of your [workflows](https://circleci.com/docs/2.0/configuration-reference/#workflows) remove the `docker/` prefix form `docker/build_image`  job name(s);

[1]: CircleCI does not seem that keen on releasing docker updates, which will limit the risk for the need to occur. The latest version available is almost 18 month old, and its the one we now use by default.