### PR TITLE
Add means to enable BuildKit

### DIFF
--- a/orbs/docker/orb.yml
+++ b/orbs/docker/orb.yml
@@ -29,6 +29,10 @@ commands:
 
   build_image:
     parameters:
+      docker_buildkit:
+        description: "Whether to enable BuildKit or not."
+        type: boolean
+        default: false
       dockerfile_path:
         description: "The path of the dockerfile to build."
         type: string
@@ -53,6 +57,7 @@ commands:
       - run:
           name: "Build the image."
           command: |
+            [ "false" != "<<parameters.docker_buildkit>>" ] && export DOCKER_BUILDKIT=1
             docker build -t <<parameters.image_name>>:<<parameters.image_tag>> \
                          --label org.opencontainers.image.vendor=JobTeaser \
                          --label org.opencontainers.image.url=https://github.com/jobteaser/$CIRCLE_PROJECT_REPONAME \
@@ -107,6 +112,10 @@ commands:
 jobs:
   build_image:
     parameters:
+      docker_buildkit:
+        description: "Whether to enable BuildKit or not."
+        type: boolean
+        default: false
       dockerfile_path:
         description: "The path of the dockerfile to build."
         type: string
@@ -133,6 +142,7 @@ jobs:
       - setup
       - login
       - build_image:
+          docker_buildkit: "<<parameters.docker_buildkit>>"
           dockerfile_path: "<<parameters.dockerfile_path>>"
           dockerfile_directory: "<<parameters.dockerfile_directory>>"
           image_name: "<<parameters.image_name>>"


### PR DESCRIPTION
Forgot that one needs to set the environment variable `DOCKER_BUILDKIT` to 1 environment variable to actually enable BuildKit.

If one wants to use the Job, AFAIK the only way is to add a parameter for it. Indeed, I can't set it in the context (would make buildkit mandatory), there is no way to add environment variables at the workflow level, no way to override the job's executor, ... amongst the many ways I tought of. Could I have missed a better way...