### PR TITLE
Make --wait optional in helm upgrade

### DIFF
--- a/orbs/helm/orb.yml
+++ b/orbs/helm/orb.yml
@@ -193,6 +193,10 @@ jobs:
         description: "The Helm release name."
         type: string
         default: "$CIRCLE_PROJECT_REPONAME-$CIRCLE_BRANCH"
+      helm_wait_for_ready:
+        description: "Whether or not to wait for the pods being actually ready."
+        type: boolean
+        default: true
       helm_upgrade_timeout:
         description: "The amount of time to wait for the Helm release upgrade to finish in seconds."
         type: integer
@@ -253,7 +257,8 @@ jobs:
               --set=circleci.sha1=$CIRCLE_SHA1 \
               --set=circleci.branch=$CIRCLE_BRANCH \
               --set=image=<<parameters.docker_image>>:<<parameters.docker_tag>> \
-              --wait --timeout=<<parameters.helm_upgrade_timeout>> \
+              --wait=<<parameters.helm_wait_for_ready>> \
+              --timeout=<<parameters.helm_upgrade_timeout>> \
               --install <<parameters.helm_release_name>> <<parameters.helm_chart_path>>
       - when:
           condition: <<parameters.tag_deployment>>


### PR DESCRIPTION
For machine learning base deployments, the pods can take some time to be ready.
For instance, [JobMatch](https://github.com/jobteaser/jobmatch) takes a couple of hours to embed all the job ads and students on the first run.
Therefore, in the CI, one would like to disable the `--wait` option in `helm upgrade`, so that the deploy job is still successful, even if the pod is not ready.

@cansjt @jobteaser/squad-foundation What do you think about it?