### PR TITLE
feat(github-tag): Put logic for tag deployment in dedicated orb

### DIFF
--- a/orbs/github/orb.yml
+++ b/orbs/github/orb.yml
@@ -23,16 +23,16 @@ commands:
                 fingerprints:
                   - <<parameters.ssh_fingerprint>>
       - checkout:
-          path: ./sources
+          path: ./sources_github
       - run:
           name: "Configure Git"
-          working_directory: ./sources
+          working_directory: ./sources_github
           command: |
             git config --global user.email "dev@jobteaser.com"
             git config --global user.name "Jobtomate CircleCI"
       - run:
           name: "Tag the deployment"
-          working_directory: ./sources
+          working_directory: ./sources_github
           command: |
             tag="deployment-<<parameters.environment>>-$(date -u +'%Y%m%d%H%M%S%N')"
             git tag $tag

--- a/orbs/github/orb.yml
+++ b/orbs/github/orb.yml
@@ -1,0 +1,38 @@
+version: 2.1
+
+description: |
+  Github toolbox for your workflows.
+
+commands:
+  tag_deployment:
+    parameters:
+      environment:
+        description: "The runtime environment."
+        type: string
+        default: "prod"
+      ssh_fingerprint:
+        description: "An ssh fingerprint (Github 'Deploy key') to allow pushing to Github."
+        type: string
+        default: ""
+    steps:
+      - when:
+          condition: <<parameters.ssh_fingerprint>>
+          steps:
+            - add_ssh_keys:
+                fingerprints:
+                  - <<parameters.ssh_fingerprint>>
+      - checkout:
+          path: ./sources
+      - run:
+          name: "Configure Git"
+          working_directory: ./sources
+          command: |
+            git config --global user.email "dev@jobteaser.com"
+            git config --global user.name "Jobtomate CircleCI"
+      - run:
+          name: "Tag the deployment"
+          working_directory: ./sources
+          command: |
+            tag="deployment-<<parameters.environment>>-$(date -u +'%Y%m%d%H%M%S%N')"
+            git tag $tag
+            git push origin $tag

--- a/orbs/github/orb.yml
+++ b/orbs/github/orb.yml
@@ -5,6 +5,7 @@ description: |
 
 commands:
   tag_deployment:
+    description: "Create a git tag named 'deployment-<environment>-<date>' and push it on origin."
     parameters:
       environment:
         description: "The runtime environment."


### PR DESCRIPTION
This PR copy some logic for deployment tagging, contained in helm orb, into its own dedicated orb. This will allow to re-use tagging commands in another repository that is not based on Helm.

(I tested this orb on a feature env deployment)