### PR TITLE
fix(build-tag-on-ci): tags are not built on CI as expected

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,10 @@ jobs:
 workflows:
   main:
     jobs:
-      - validate
+      - validate:
+          filters:
+            tags:
+              only: "/^v.*/"
       - publish_dev:
           requires: ["validate"]
       - publish_stable:


### PR DESCRIPTION
This PR fixes the following issue: the publishing of stable orbs is never done because the `validate` job that `publish_stable` job depends on is never run by CircleCI (by default CircleCI does NOT trigger builds for tags - see https://circleci.com/docs/2.0/configuration-reference/#tags).