### PR TITLE
feat(orb-circleci): create dedicated orb for concurrent deployment management

### DIFF
--- a/orbs/circleci/Dockerfile.concurrent
+++ b/orbs/circleci/Dockerfile.concurrent
@@ -1,0 +1,23 @@
+FROM ubuntu:20.04
+
+LABEL vendor="JobTeaser"
+LABEL maintainer="squad-devex@jobteaser.com"
+
+ENV DEBIAN_FRONTEND noninteractive
+
+COPY circle-wait-job /bin/circle-wait-job
+COPY deployable /bin/deployable
+
+RUN apt-get update -y && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+      # base
+      wget ca-certificates \
+      # checkout
+      git openssh-client \
+      # circle-wait-job
+      ruby \
+    && \
+    rm -rf /var/lib/apt/lists/* && \
+    apt-get autoremove -y && \
+    apt-get clean -y

--- a/orbs/circleci/circle-wait-job
+++ b/orbs/circleci/circle-wait-job
@@ -10,6 +10,7 @@ class CLI
 
   def initialize
     @branch = ENV["CIRCLE_BRANCH"]
+    # interval is specified in seconds
     @interval = "60"
     @vcs = "github"
     @build_number = ENV["CIRCLE_BUILD_NUM"]

--- a/orbs/circleci/circle-wait-job
+++ b/orbs/circleci/circle-wait-job
@@ -1,0 +1,180 @@
+#!/usr/bin/env ruby
+
+require("optparse")
+require("net/http")
+require("json")
+require("date")
+
+class CLI
+  attr_reader(:token, :organization, :project, :job, :current_job, :branch, :interval, :vcs, :build_number)
+
+  def initialize
+    @branch = ENV["CIRCLE_BRANCH"]
+    @interval = "60"
+    @vcs = "github"
+    @build_number = ENV["CIRCLE_BUILD_NUM"]
+    @token = ENV["CIRCLE_TOKEN"]
+    @current_job = ENV["CIRCLE_JOB"]
+    @job = ENV["CIRCLE_JOB"]
+    @organization = ENV["CIRCLE_PROJECT_USERNAME"]
+    @project = ENV["CIRCLE_PROJECT_REPONAME"]
+  end
+
+  def parse(args)
+    OptionParser.new do |parser|
+      define_options!(parser)
+      parser.parse!(args)
+    end
+
+    must_not_empty("branch", @branch)
+    must_not_empty("interval", @interval)
+    must_not_empty("vcs", @vcs)
+    must_not_empty("current-build-number", @build_number)
+    must_not_empty("token", @token)
+    must_not_empty("job", @job)
+    must_not_empty("current_job", @current_job)
+    must_not_empty("organization", @organization)
+    must_not_empty("project", @project)
+
+    self
+  end
+
+  private
+
+  def must_not_empty(key, value)
+    if value.to_s.empty?
+      raise(ArgumentError, "the #{key} is missing or empty")
+    end
+  end
+
+  def define_options!(parser)
+    parser.banner = "Usage: circleci-wait-job OPTIONS"
+    parser.separator("")
+    parser.separator("OPTIONS")
+    parser.separator("")
+
+    parser.on("-t=VALUE", "--token=VALUE", "the circleci api token") { |value| @token = value }
+    parser.on("-o=VALUE", "--organization=VALUE", "the circleci organization name") { |value| @organization = value }
+    parser.on("-p=VALUE", "--project=VALUE", "the circleci project name") { |value| @project = value }
+    parser.on("-j=VALUE", "--job=VALUE", "the circleci job name") { |value| @job = value }
+    parser.on("-c=VALUE", "--current_job=VALUE", "the circleci currently running job name") { |value| @current_job = value }
+    parser.on("-b=VALUE", "--branch=VALUE", "the circleci branch") { |value| @branch = value }
+    parser.on("-i=VALUE", "--interval=VALUE", "the wait time between pooling") { |value| @interval = value }
+    parser.on("--vcs=VALUE", "the version control system (default: github)") { |value| @vcs = value }
+    parser.on("--current-build-number=VALUE", "the current circleci build number") { |value| @build_number = value }
+
+    parser.on_tail("-h", "--help", "print help and exit") do
+      puts(parser)
+      exit(0)
+    end
+
+    parser.on_tail("--version", "print version and exit") do
+      puts("v0.0.1")
+      exit(0)
+    end
+  end
+end
+
+cli = CLI.new
+
+begin
+  options = cli.parse(ARGV)
+rescue ArgumentError => e
+  puts(e.message)
+  exit(1)
+end
+
+uri = URI::HTTPS.build(host: "circleci.com",
+                       path: File.join("/",
+                                       "api",
+                                       "v1.1",
+                                       "project",
+                                       options.vcs.to_s,
+                                       options.organization.to_s,
+                                       options.project.to_s,
+                                       "tree",
+                                       options.branch.to_s),
+                       query: URI.encode_www_form({"circle-token" => options.token.to_s,
+                                                   "shallow" => true,
+                                                   "filter" => "running"}))
+
+
+def other_job_is_running?(uri, job, current_job, build_num)
+  response = Net::HTTP.get(uri)
+  builds = JSON.parse(response)
+
+  # Check if another identical job (most likely a production deployment job) is running for another build
+  has_concurrent_job = builds.any? do |build|
+    is_concurrent_build = build.dig("workflows", "job_name").to_s == job && build["build_num"] != build_num
+
+    puts("Checking #{build.dig("build_url")}...")
+    puts("\t" + (is_concurrent_build ? "Is a concurrent build!" : "Not a concurrent build."))
+
+    is_concurrent_build
+  end
+
+  puts(
+    "\n" +
+    (has_concurrent_job ? "Found concurrent job" : "No concurrent job found")
+  )
+
+  if has_concurrent_job
+    return true
+  else
+    puts("Check that no other builds are currently running job #{current_job}...")
+    # We know that no "production deployment job" is running but there is a possibility that 2 builds are
+    # running the same job as the current one simultaneously. This means that both builds could enter a
+    # "production deployment job" at the same time after the present job is done. We must avoid it.
+    # Check if another other build is running the same job as the current one (most likely a
+    # concurrent_build_management job).
+    # Iterate on builds and regroup builds by job name in a dict:
+    # Ex: { concurrent_build_management: [build1, build2], test_js: [build3], ...}
+    builds_by_job_name = Hash.new
+    builds.each_entry do |build|
+      build_job_name = build.dig("workflows", "job_name").to_s
+      builds_by_job_name[build_job_name] = builds_by_job_name[build_job_name] || []
+      builds_by_job_name[build_job_name].push(build)
+    end
+
+    # Look for builds that have a job name == current_job since the present script is expected to
+    # be called for a job whose concurrent run is not allowed
+    concurrent_builds_for_current_job = builds_by_job_name[current_job]
+
+    if !concurrent_builds_for_current_job || concurrent_builds_for_current_job.length() == 0
+      puts "No builds running job #{current_job} were found."
+      return false
+    end
+
+    puts "Checking which concurrent build is the oldest (from commit perspective)..."
+
+    # Find build for the oldest code
+    oldestBuild = concurrent_builds_for_current_job.first
+    oldestCommitDate = DateTime.parse(oldestBuild.dig("committer_date"))
+    concurrent_builds_for_current_job.each_entry do |build|
+      puts "Comparing build #{build.dig("build_url")} with commit date #{build.dig("committer_date")}"
+      buildCommitDate = DateTime.parse(build.dig("committer_date"))
+      if buildCommitDate <= oldestCommitDate
+        puts "\tBuild is older"
+        oldestCommitDate = buildCommitDate
+        oldestBuild = build
+      else
+        puts "\tBuild is newer"
+      end
+    end
+
+    if build_num == oldestBuild.dig("build_num")
+      puts "\nCurrent build has the oldest code, it can continue running"
+      return false
+    else
+      puts "\nCurrent build has code more recent that another one running, it must wait"
+      return true
+    end
+  end
+end
+
+puts("Check no other #{options.job} for #{options.branch} branch is running.")
+
+while other_job_is_running?(uri, options.job.to_s, options.current_job.to_s, options.build_number.to_i) do
+  puts("Another #{options.job} for #{options.branch} branch already running, check again in #{options.interval} seconds.\n")
+  sleep(options.interval.to_i)
+end

--- a/orbs/circleci/circle-wait-job
+++ b/orbs/circleci/circle-wait-job
@@ -105,7 +105,7 @@ def other_job_is_running?(uri, job, current_job, build_num)
 
   # Check if another identical job (most likely a production deployment job) is running for another build
   has_concurrent_job = builds.any? do |build|
-    is_concurrent_build = build.dig("workflows", "job_name").to_s == job && build["build_num"] != build_num
+    is_concurrent_build = build.dig("workflows", "job_name").to_s == job
 
     puts("Checking #{build.dig("build_url")}...")
     puts("\t" + (is_concurrent_build ? "Is a concurrent build!" : "Not a concurrent build."))

--- a/orbs/circleci/deployable
+++ b/orbs/circleci/deployable
@@ -1,0 +1,47 @@
+#!/usr/bin/env sh
+
+set -eu
+
+fatal() {
+    printf "$*\n" >/dev/stderr
+    exit 1
+}
+
+usage() {
+    cat <<EOF
+usage: $0 OPTIONS <name>
+
+OPTIONS
+
+-h display help
+-p tag pattern (default: $pattern)
+EOF
+}
+
+pattern="*"
+
+OPTIND=1
+while getopts 'hp:' arg; do
+    case "$arg" in
+	h) usage; exit 0 ;;
+	p) pattern="$OPTARG" ;;
+	?) fatal "unknown option" ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+if [ ! -d ".git" ]; then
+    fatal "no git repository found"
+fi
+
+last_tag=$(git tag --sort version:refname --list "$pattern" | tail -1)
+if [ -z "$last_tag" ]; then
+    exit 0
+fi
+
+deployed_sha1=$(git rev-parse "$last_tag")
+current_sha1=$(git rev-parse HEAD)
+
+if [ "$(git rev-list $deployed_sha1 | grep $current_sha1)" ]; then
+    fatal "ERROR: The current code you intend to deploy is older than the one present on production."
+fi

--- a/orbs/circleci/orb.yml
+++ b/orbs/circleci/orb.yml
@@ -6,7 +6,7 @@ description: |
 executors:
   concurrent:
     docker:
-      - image: "jobteaser/circleci-circleci-concurrent:0.0.9"
+      - image: "jobteaser/circleci-circleci-concurrent:0.0.10"
         auth:
           username: "$DOCKER_LOGIN"
           password: "$DOCKER_PASSWORD"

--- a/orbs/circleci/orb.yml
+++ b/orbs/circleci/orb.yml
@@ -6,7 +6,7 @@ description: |
 executors:
   concurrent:
     docker:
-      - image: "jobteaser/circleci-circleci-concurrent:0.0.10"
+      - image: "jobteaser/circleci-circleci-concurrent:0.0.11"
         auth:
           username: "$DOCKER_LOGIN"
           password: "$DOCKER_PASSWORD"

--- a/orbs/circleci/orb.yml
+++ b/orbs/circleci/orb.yml
@@ -1,0 +1,75 @@
+version: 2.1
+
+description: |
+  CircleCI commmand utilities.
+
+executors:
+  concurrent:
+    docker:
+      - image: "jobteaser/circleci-circleci-concurrent:0.0.9"
+        auth:
+          username: "$DOCKER_LOGIN"
+          password: "$DOCKER_PASSWORD"
+
+commands:
+  wait_on_concurrent_job:
+    description: "Delay present build if concurrent builds running the same job, exist."
+    parameters:
+      job_name:
+        description: "The name of the job that should be running only one at a time."
+        type: string
+        default: "deploy"
+      polling_interval:
+        description: "The polling interval to wait when concurrent jobs are running (in seconds)."
+        type: integer
+        default: 60
+    steps:
+      - run:
+          name: "Wait for all other builds to complete"
+          command: |
+            circle-wait-job \
+              -j <<parameters.job_name>> \
+              -i <<parameters.polling_interval>>
+  stop_if_stale:
+    description: "Stop a build if HEAD of current branch is already present on production."
+    parameters:
+      environment:
+        description: "The runtime environment."
+        type: string
+        default: "prod"
+    steps:
+      - run:
+          working_directory: ./sources_circleci
+          name: "Ensure that this build is more recent than the last deployed one"
+          command: |
+            deployable -p "deployment-<<parameters.environment>>-*"
+
+jobs:
+  concurrent_build_management:
+    description: >
+      A job to be run before a deployment job to ensure that no concurrent
+      deployment job are running.
+    executor: "concurrent"
+    parameters:
+      environment:
+        description: "The runtime environment."
+        type: string
+        default: "prod"
+      job_name:
+        description: "The name of the job that should be running only one at a time."
+        type: string
+        default: "deploy"
+      polling_interval:
+        description: "The polling interval to wait when concurrent jobs are running (in seconds)."
+        type: integer
+        default: 60
+    steps:
+      - checkout:
+          path: ./sources_circleci
+      # "wait_on_concurrent_job" ensures that builds are delivered in the right "older to newer" order
+      - wait_on_concurrent_job:
+          job_name: <<parameters.job_name>>
+          polling_interval: <<parameters.polling_interval>>
+      # "stop_if_stale" ensures that builds for code that already present on production are not deployed again
+      - stop_if_stale:
+          environment: <<parameters.environment>>


### PR DESCRIPTION
This PR copies some logic for concurrent deployment on production, in a dedicated Orb (copied from `helm` Orb). It also improve a bit the strategy to avoid a possible deadlock that happens when 2 deployment jobs are waiting for each other (happens sometimes on the monolith today).
This new dedicated orb was initially created to be used in frontend repo `ui-jobteaser` but it could really be used anywhere.

## Behavior
This concurrent deployment feature is exposed as a job `circleci/concurrent_build_management` that must be called before the "deploy" job of a given project.

Ex:

```yaml
      - circleci/concurrent_build_management:
          # This job:
          # - Check that there is not other "deploy_prod" job running
          # - Check that the version being deployed is more recent than the one on prod
          name: "concurrent_build_management"
          context: "deploy_prod"
          requires: ["lint_js", "lint_css", "test_js", "build"]
          filters:
            branches:
              only:
                - master
          # Orb custom parameters:
          job_name: "deploy_prod"
          polling_interval: 5
      - deploy_prod:
          context: "build"
          requires: ["concurrent_build_management"]
          filters:
            branches:
              only:
                - master
```