### PR TITLE
Fix helm still using defunct repository

### DIFF
--- a/orbs/helm/orb.yml
+++ b/orbs/helm/orb.yml
@@ -150,6 +150,7 @@ jobs:
             cd <<parameters.helm_chart_path>>
             helm init --client-only --stable-repo-url https://charts.helm.sh/stable
             helm plugin install https://github.com/chartmuseum/helm-push
+            helm repo add stable https://charts.helm.sh/stable
             helm repo add --username <<parameters.helm_repo_user>> --password <<parameters.helm_repo_pass>> jobteaser-private <<parameters.helm_repo_url>>
             helm repo add jobteaser-public https://jobteaser.github.io/charts
             helm repo update
@@ -251,6 +252,7 @@ jobs:
           command: |
             cd <<parameters.helm_chart_path>>
             helm init --client-only --stable-repo-url https://charts.helm.sh/stable
+            helm repo add stable https://charts.helm.sh/stable
             helm repo add jobteaser https://jobteaser.github.io/charts
             helm dep update
       - when:


### PR DESCRIPTION
Since Helm changed the address of their stable public chart repo, we still sometimes have issues with it looking for the old one sometimes. This works around that issue.

https://helm.sh/blog/new-location-stable-incubator-charts/

Will test this on my [broken build](https://app.circleci.com/pipelines/github/jobteaser/jobflow/452/workflows/d2ccb1e4-788d-4c59-9b2b-88f52ac83fcd/jobs/1326).