### PR TITLE
feat(rb-service): add executors with version

### DIFF
--- a/orbs/go-service/orb.yml
+++ b/orbs/go-service/orb.yml
@@ -9,11 +9,19 @@ orbs:
 
 executors:
   ci:
+    # We should avoid using latest image tag.
+    # Prefer using specific tag to avoid breaking your CI when a breaking change in the image occurs.
     docker:
-      - image: "jobteaser/go-service-ci:latest"
+      - image: "jobteaser/go-service-ci:<<parameters.tag>>"
         auth:
           username: "$DOCKER_LOGIN"
           password: "$DOCKER_PASSWORD"
+    parameters:
+      tag:
+        default: 'latest'
+        description: >
+          Pick a specific jobteaser/go-service-ci image version tag
+        type: string
 
 commands:
   save_go_pkg_cache:

--- a/orbs/py-service/orb.yml
+++ b/orbs/py-service/orb.yml
@@ -9,11 +9,19 @@ orbs:
 
 executors:
   ci:
+    # We should avoid using latest image tag.
+    # Prefer using specific tag to avoid breaking your CI when a breaking change in the image occurs.
     docker:
-      - image: "jobteaser/py-service-ci:latest"
+      - image: "jobteaser/py-service-ci:<<parameters.tag>>"
         auth:
           username: "$DOCKER_LOGIN"
           password: "$DOCKER_PASSWORD"
+    parameters:
+      tag:
+        default: 'latest'
+        description: >
+          Pick a specific jobteaser/py-service-ci image version tag
+        type: string
 
 jobs:
   test:

--- a/orbs/rb-service/orb.yml
+++ b/orbs/rb-service/orb.yml
@@ -9,11 +9,19 @@ orbs:
 
 executors:
   ci:
+    # We should avoid using latest image tag.
+    # Prefer using specific tag to avoid breaking your CI when a breaking change in the image occurs.
     docker:
-      - image: "jobteaser/rb-service-ci:latest"
+      - image: "jobteaser/rb-service-ci:<<parameters.tag>>"
         auth:
           username: "$DOCKER_LOGIN"
           password: "$DOCKER_PASSWORD"
+    parameters:
+      tag:
+        default: 'latest'
+        description: >
+          Pick a specific jobteaser/rb-service-ci image version tag
+        type: string
 
 commands:
   save_ruby_bundle_cache:


### PR DESCRIPTION
Using latest, an update of an image will
impact all services. In case of bug fixes,
it seems an advantage, but it may become
a nightmare in case of breaking changes.

That's why it is preferable to use executor
with image which target a specific version.

It allows to migrate easily and smoothly to
a new version of ruby or any other impactful
dependencies.

In order to keep these image up to date like
the latest image, we should refresh all tagged
images nightly.