### PR TITLE
fix(circle-wait-job): avoid deadlock and handle edge case due to latency

### DIFF
--- a/orbs/circleci/circle-wait-job
+++ b/orbs/circleci/circle-wait-job
@@ -85,7 +85,7 @@ rescue ArgumentError => e
   exit(1)
 end
 
-uri = URI::HTTPS.build(host: "circleci.com",
+uri_for_running = URI::HTTPS.build(host: "circleci.com",
                        path: File.join("/",
                                        "api",
                                        "v1.1",
@@ -99,10 +99,24 @@ uri = URI::HTTPS.build(host: "circleci.com",
                                                    "shallow" => true,
                                                    "filter" => "running"}))
 
+uri_for_successful = URI::HTTPS.build(host: "circleci.com",
+                       path: File.join("/",
+                                       "api",
+                                       "v1.1",
+                                       "project",
+                                       options.vcs.to_s,
+                                       options.organization.to_s,
+                                       options.project.to_s,
+                                       "tree",
+                                       options.branch.to_s),
+                       query: URI.encode_www_form({"circle-token" => options.token.to_s,
+                                                   "shallow" => true,
+                                                   "filter" => "successful"}))
 
-def other_job_is_running?(uri, targeted_job, current_job, current_build_num)
-  response = Net::HTTP.get(uri)
-  builds = JSON.parse(response)
+
+def other_job_is_running?(uri_for_running, uri_for_successful, targeted_job, current_job, current_build_num)
+  response = Net::HTTP.get(uri_for_running)
+  running_builds = JSON.parse(response)
 
   # Check if another targeted job (most likely a production deployment job) is already running.
   has_concurrent_job = builds.any? do |build|
@@ -135,24 +149,46 @@ def other_job_is_running?(uri, targeted_job, current_job, current_build_num)
 
     # Find build for the oldest code
     oldestBuild = concurrent_builds_for_current_job.min do |build1, build2|
-      DateTime.parse(build1.dig("committer_date")) <=> DateTime.parse(build2.dig("committer_date"))
+      DateTime.parse(build1["committer_date"]) <=> DateTime.parse(build2["committer_date"])
     end
 
     puts "Oldest build is #{oldestBuild["build_num"]}"
 
-    if current_build_num == oldestBuild["build_num"]
-      puts "\nCurrent build has the oldest code, it can continue running"
-      return false
-    else
+    if current_build_num != oldestBuild["build_num"]
       puts "\nCurrent build has code more recent that another one running, it must wait"
       return true
+    end
+
+    puts "\nCurrent build has the oldest code, it can continue running"
+
+    # There is generally around 4 seconds between a job being successful and the following job being running.
+    # It means it is possible that an older job similar to the current job just successful and that
+    # the associate targeted job has not started yet.
+    # In this case, two target jobs would run concurrently.
+    # To avoid this edge case, we ensure that no jobs similar to the current job successful a few seconds ago.
+    response = Net::HTTP.get(uri_for_successful)
+    successful_builds = JSON.parse(response)
+    few_seconds_ago = Time.now - 30 # observed latency are up to 10 seconds.
+
+    puts "\nChecking if a build has successfully runned #{current_job} few seconds ago..."
+    may_have_concurrent_job = successful_builds.any? do |build|
+      build.dig("workflows", "job_name").to_s == current_job && DateTime.parse(build["stop_time"]) > few_seconds_ago
+    end
+
+    if may_have_concurrent_job
+      puts "A build has successfully runned #{current_job} few seconds ago."
+      puts "Another build may start #{targeted_job} in few seconds."
+      return true
+    else
+      puts "No builds successfully runned job #{current_job} few seconds ago."
+      return false
     end
   end
 end
 
 puts("Check no other #{options.job} for #{options.branch} branch is running.")
 
-while other_job_is_running?(uri, options.job.to_s, options.current_job.to_s, options.build_number.to_i) do
+while other_job_is_running?(uri_for_running, uri_for_successful, options.job.to_s, options.current_job.to_s, options.build_number.to_i) do
   puts("Another #{options.job} for #{options.branch} branch already running, check again in #{options.interval} seconds.\n")
   sleep(options.interval.to_i)
 end

--- a/orbs/circleci/circle-wait-job
+++ b/orbs/circleci/circle-wait-job
@@ -100,29 +100,21 @@ uri = URI::HTTPS.build(host: "circleci.com",
                                                    "filter" => "running"}))
 
 
-def other_job_is_running?(uri, job, current_job, build_num)
+def other_job_is_running?(uri, targeted_job, current_job, current_build_num)
   response = Net::HTTP.get(uri)
   builds = JSON.parse(response)
 
-  # Check if another identical job (most likely a production deployment job) is running for another build
+  # Check if another targeted job (most likely a production deployment job) is already running.
   has_concurrent_job = builds.any? do |build|
-    is_concurrent_build = build.dig("workflows", "job_name").to_s == job
-
-    puts("Checking #{build.dig("build_url")}...")
-    puts("\t" + (is_concurrent_build ? "Is a concurrent build!" : "Not a concurrent build."))
-
-    is_concurrent_build
+    build.dig("workflows", "job_name").to_s == targeted_job
   end
 
-  puts(
-    "\n" +
-    (has_concurrent_job ? "Found concurrent job" : "No concurrent job found")
-  )
-
   if has_concurrent_job
+    puts "A build is already running the job #{targeted_job}."
     return true
   else
-    puts("Check that no other builds are currently running job #{current_job}...")
+    puts "No build running job #{targeted_job} were found."
+    puts "\nChecking that no other builds are currently running job #{current_job}..."
     # We know that no "production deployment job" is running but there is a possibility that 2 builds are
     # running the same job as the current one simultaneously. This means that both builds could enter a
     # "production deployment job" at the same time after the present job is done. We must avoid it.
@@ -130,40 +122,25 @@ def other_job_is_running?(uri, job, current_job, build_num)
     # concurrent_build_management job).
     # Iterate on builds and regroup builds by job name in a dict:
     # Ex: { concurrent_build_management: [build1, build2], test_js: [build3], ...}
-    builds_by_job_name = Hash.new
-    builds.each_entry do |build|
-      build_job_name = build.dig("workflows", "job_name").to_s
-      builds_by_job_name[build_job_name] = builds_by_job_name[build_job_name] || []
-      builds_by_job_name[build_job_name].push(build)
+    concurrent_builds_for_current_job = builds.select do |build|
+      build.dig("workflows", "job_name").to_s == current_job
     end
 
-    # Look for builds that have a job name == current_job since the present script is expected to
-    # be called for a job whose concurrent run is not allowed
-    concurrent_builds_for_current_job = builds_by_job_name[current_job]
-
-    if !concurrent_builds_for_current_job || concurrent_builds_for_current_job.length() == 0
+    unless concurrent_builds_for_current_job.any?
       puts "No builds running job #{current_job} were found."
       return false
     end
 
-    puts "Checking which concurrent build is the oldest (from commit perspective)..."
+    puts "\nChecking which concurrent build is the oldest (based on committer_date)..."
 
     # Find build for the oldest code
-    oldestBuild = concurrent_builds_for_current_job.first
-    oldestCommitDate = DateTime.parse(oldestBuild.dig("committer_date"))
-    concurrent_builds_for_current_job.each_entry do |build|
-      puts "Comparing build #{build.dig("build_url")} with commit date #{build.dig("committer_date")}"
-      buildCommitDate = DateTime.parse(build.dig("committer_date"))
-      if buildCommitDate <= oldestCommitDate
-        puts "\tBuild is older"
-        oldestCommitDate = buildCommitDate
-        oldestBuild = build
-      else
-        puts "\tBuild is newer"
-      end
+    oldestBuild = concurrent_builds_for_current_job.min do |build1, build2|
+      DateTime.parse(build1.dig("committer_date")) <=> DateTime.parse(build2.dig("committer_date"))
     end
 
-    if build_num == oldestBuild.dig("build_num")
+    puts "Oldest build is #{oldestBuild["build_num"]}"
+
+    if current_build_num == oldestBuild["build_num"]
       puts "\nCurrent build has the oldest code, it can continue running"
       return false
     else

--- a/orbs/helm/circle-wait-job
+++ b/orbs/helm/circle-wait-job
@@ -65,7 +65,7 @@ class CLI
     end
 
     parser.on_tail("--version", "print version and exit") do
-      puts("v0.0.1")
+      puts("v0.0.2")
       exit(0)
     end
   end
@@ -94,19 +94,44 @@ uri = URI::HTTPS.build(host: "circleci.com",
                                                    "shallow" => true,
                                                    "filter" => "running"}))
 
-
+# CircleCI doesn't have built in way to avoid running to job at the same time on the same branch.
+# It means we have handle it manually.
+# Our main goal here is to avoid two helm deployement at the same time. It may impact badly the stability of the plateform.
+#
+# The easiest way to achieve is to add a task at the beginning of the job which wait if another build is running the same job.
+# It works fine until a deadlock, where two jobs are waiting each other.
+#
+# The issue come from the difficulty to known if the other job is already deploying our just waiting.
+# In case of concurrency, we can favor the build with the older committer_date, but we have no garanty that the other one is not deploying.
+# Indeed, a workflow can be runned faster than another one leading to a newest committer_date being deployed before the older.
+# Then, the use of committer_date avoid deadlock but may lead to concurrent deployment.
+#
+# Because we cannot determine if concurrent builds are already deploying or not, the most safe way to avoid both, concurrent deployment and deadlock, is to follow a first in first out logic.
+# The first build may not be aware of the second build and may have started to deploy.
+# At the opposite, the second build is always aware of the first build and can wait for its completion before deploying.
+# There is no risk of concurrency neither deadlock.
+#
+# We can use the build_num to easily know the first build. However, the builnumber is set at the queue time and not at the start time.
+# It means it correspond to the order of queue and not start.
+# It is possible for a build to start before another build that has been queued first.
+# I would be more correct to use "start_time". But the build number is safe enough.
+# The time between queue and start is less than 10 seconds whereas the time to setup the env is 20 second.
+# If this case happen, both build will be aware of the existence of the other one.
 def other_job_is_running?(uri, job, build_num)
   response = Net::HTTP.get(uri)
   builds = JSON.parse(response)
 
   builds.any? do |build|
-    build.dig("workflows", "job_name").to_s == job && build["build_num"] != build_num
+    if build.dig("workflows", "job_name").to_s == job && build["build_num"].to_i < build_num
+      puts "Build #{build["build_num"].to_i} is already running the job #{build.dig("workflows", "job_name").to_s} on the same branch."
+      true
+    end
   end
 end
 
-puts("Check no other #{options.job} for #{options.branch} branch is running")
+puts("Avoid neither concurrent #{options.job} for branch #{options.branch} nor deadlock happen.")
 
 while other_job_is_running?(uri, options.job.to_s, options.build_number.to_i) do
-  puts("Another #{options.job} for #{options.branch} branch already running, check again in #{options.interval} seconds.")
+  puts "Sleep #{options.interval} seconds before a new check")
   sleep(options.interval)
 end


### PR DESCRIPTION
# CircleCI doesn't have built in way to avoid running to job at the same time on the same branch.
# It means we have handle it manually.
# Our main goal here is to avoid two helm deployement at the same time. It may impact badly the stability of the plateform.
#
# The easiest way to achieve is to add a task at the beginning of the job which wait if another build is running the same job.
# It works fine until a deadlock, where two jobs are waiting each other.
#
# The issue come from the difficulty to known if the other job is already deploying our just waiting.
# In case of concurrency, we can favor the build with the older committer_date, but we have no garanty that the other one is not deploying.
# Indeed, a workflow can be runned faster than another one leading to a newest committer_date being deployed before the older.
# Then, the use of committer_date avoid deadlock but may lead to concurrent deployment.
#
# Because we cannot determine if concurrent builds are already deploying or not, the most safe way to avoid both, concurrent deployment and deadlock, is to follow a first in first out logic.
# The first build may not be aware of the second build and may have started to deploy.
# At the opposite, the second build is always aware of the first build and can wait for its completion before deploying.
# There is no risk of concurrency neither deadlock.
#
# We can use the build_num to easily know the first build. However, the builnumber is set at the queue time and not at the start time.
# It means it correspond to the order of queue and not start.
# It is possible for a build to start before another build that has been queued first.
# I would be more correct to use "start_time". But the build number is safe enough.
# The time between queue and start is less than 10 seconds whereas the time to setup the env is 20 second.
# If this case happen, both build will be aware of the existence of the other one.



There is generally around 4 seconds between a job being successful and the following job being running.
It means it is possible that an older job similar to the current job just successful and that
the associate targeted job has not started yet.
In this case, two target jobs would run concurrently.
To avoid this edge case, we ensure that no jobs similar to the current job successful a few seconds ago.