### PR TITLE
chore(orb/helm): upgrade helm client to v3.6.3

### DIFF
--- a/orbs/helm/Dockerfile.deploy
+++ b/orbs/helm/Dockerfile.deploy
@@ -3,7 +3,7 @@ FROM ubuntu:20.04
 LABEL vendor="JobTeaser"
 LABEL maintainer="foundation@jobteaser.com"
 
-ENV HELM_VERSION 2.12.3
+ENV HELM_VERSION 3.6.3
 ENV KUBE_VERSION 1.18.8
 
 ENV DEBIAN_FRONTEND noninteractive
@@ -32,8 +32,7 @@ RUN apt-get update -y && \
       wget -q https://get.helm.sh/helm-v$HELM_VERSION-linux-amd64.tar.gz && \
       tar -xzf helm-v$HELM_VERSION-linux-amd64.tar.gz && \
       cd linux-amd64 && \
-      install -m755 helm /usr/local/bin/helm && \
-      install -m755 tiller /usr/local/bin/tiller \
+      install -m755 helm /usr/local/bin/helm \
     ) && \
     \
     apt-get autoremove -y && \

--- a/orbs/helm/orb.yml
+++ b/orbs/helm/orb.yml
@@ -76,6 +76,10 @@ commands:
         description: "The runtime environment."
         type: string
         default: "prod"
+      kubernetes_namespace:
+        description: "The Kubernetes namespace."
+        type: string
+        default: "$CIRCLE_PROJECT_REPONAME"
       helm_chart_path:
         description: "The path of the Helm chart."
         type: string
@@ -94,12 +98,12 @@ commands:
           command: |
             mkdir -p /tmp/helm-templates/<<parameters.environment>>
             helm template \
-              -n <<parameters.helm_release_name>> \
+              <<parameters.helm_release_name>> <<parameters.helm_chart_path>> \
+              -n <<parameters.kubernetes_namespace>> \
               -f <<parameters.helm_value_file_path>> \
               --set=circleci.sha1=$CIRCLE_SHA1 \
               --set=circleci.branch=$CIRCLE_BRANCH \
-              --output-dir /tmp/helm-templates/<<parameters.environment>> \
-              <<parameters.helm_chart_path>>
+              --output-dir /tmp/helm-templates/<<parameters.environment>>
       - store_artifacts:
           path: "/tmp/helm-templates/<<parameters.environment>>"
 
@@ -148,7 +152,6 @@ jobs:
           name: "Push Helm chart to remote repo"
           command: |
             cd <<parameters.helm_chart_path>>
-            helm init --client-only --stable-repo-url https://charts.helm.sh/stable
             helm plugin install https://github.com/chartmuseum/helm-push
             helm repo add --username <<parameters.helm_repo_user>> --password <<parameters.helm_repo_pass>> jobteaser-private <<parameters.helm_repo_url>>
             helm repo add jobteaser-public https://jobteaser.github.io/charts
@@ -254,7 +257,6 @@ jobs:
           name: "Initialize Helm"
           command: |
             cd <<parameters.helm_chart_path>>
-            helm init --client-only --stable-repo-url https://charts.helm.sh/stable
             helm repo add jobteaser https://jobteaser.github.io/charts
             helm dep update
       - when:
@@ -273,7 +275,7 @@ jobs:
           no_output_timeout: <<parameters.no_output_timeout>>
           command: |
             helm upgrade \
-              --tiller-namespace=<<parameters.kubernetes_namespace>> \
+              <<parameters.helm_release_name>> <<parameters.helm_chart_path>> \
               --namespace=<<parameters.kubernetes_namespace>> \
               -f <<parameters.helm_value_file_path>> \
               --set=circleci.sha1=$CIRCLE_SHA1 \
@@ -281,7 +283,7 @@ jobs:
               --set=image=<<parameters.docker_image>>:<<parameters.docker_tag>> \
               --wait=<<parameters.helm_wait_for_ready>> \
               --timeout=<<parameters.helm_upgrade_timeout>> \
-              --install <<parameters.helm_release_name>> <<parameters.helm_chart_path>>
+              --install
       - when:
           condition: <<parameters.tag_deployment>>
           steps:


### PR DESCRIPTION
helm 2 is deprecated and we MUST move to helm 3 since the tiller server is no more pullable from public registry
