### PR TITLE
feat: Print helm deploy command before running it

### DIFF
--- a/orbs/helm/orb.yml
+++ b/orbs/helm/orb.yml
@@ -271,6 +271,20 @@ jobs:
           helm_release_name: "<<parameters.helm_release_name>>"
           helm_value_file_path: "<<parameters.helm_value_file_path>>"
       - run:
+          name: "Print install/upgrade command in case we need to run it manually"
+          no_output_timeout: <<parameters.no_output_timeout>>
+          command: |
+            echo helm upgrade \
+              <<parameters.helm_release_name>> <<parameters.helm_chart_path>> \
+              --namespace=<<parameters.kubernetes_namespace>> \
+              -f <<parameters.helm_value_file_path>> \
+              --set=circleci.sha1=$CIRCLE_SHA1 \
+              --set=circleci.branch=$CIRCLE_BRANCH \
+              --set=image=<<parameters.docker_image>>:<<parameters.docker_tag>> \
+              --wait=<<parameters.helm_wait_for_ready>> \
+              --timeout=<<parameters.helm_upgrade_timeout>>s \
+              --install
+      - run:
           name: "Install or upgrade the Helm release"
           no_output_timeout: <<parameters.no_output_timeout>>
           command: |


### PR DESCRIPTION
So we can copy it to deploy by hand in case our workaround for the
docker images pulling issue doesn't work:

https://github.com/jobteaser/jobteaser/commit/abf15e643b706961b23d90422a67e80e0e61f3b3
https://jobteaser.slack.com/archives/CB2RB1DLM/p1631630805087600