### PR TITLE
revert: Print helm deploy command before running

### DIFF
--- a/orbs/helm/orb.yml
+++ b/orbs/helm/orb.yml
@@ -271,20 +271,6 @@ jobs:
           helm_release_name: "<<parameters.helm_release_name>>"
           helm_value_file_path: "<<parameters.helm_value_file_path>>"
       - run:
-          name: "Print install/upgrade command in case we need to run it manually"
-          no_output_timeout: <<parameters.no_output_timeout>>
-          command: |
-            echo helm upgrade \
-              <<parameters.helm_release_name>> <<parameters.helm_chart_path>> \
-              --namespace=<<parameters.kubernetes_namespace>> \
-              -f <<parameters.helm_value_file_path>> \
-              --set=circleci.sha1=$CIRCLE_SHA1 \
-              --set=circleci.branch=$CIRCLE_BRANCH \
-              --set=image=<<parameters.docker_image>>:<<parameters.docker_tag>> \
-              --wait=<<parameters.helm_wait_for_ready>> \
-              --timeout=<<parameters.helm_upgrade_timeout>>s \
-              --install
-      - run:
           name: "Install or upgrade the Helm release"
           no_output_timeout: <<parameters.no_output_timeout>>
           command: |


### PR DESCRIPTION
This reverts commit b1bfce94a8db2446e78437d2d3982054f5473bec.

- It doesn't work as expected (docker image name is obfuscated)
- I'm lacking the time to investigate more
- Deployment is basically back to normal anyway