### PR TITLE
feat(node/npm): upgrade node/npm version to 16/7

### DIFF
--- a/orbs/changelog/Dockerfile.publish
+++ b/orbs/changelog/Dockerfile.publish
@@ -4,8 +4,8 @@ LABEL vendor="JobTeaser"
 LABEL maintainer="opensource@jobteaser.com"
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV NODE_VERSION 14.17.6
-ENV NPM_VERSION 7.24.1
+ENV NODE_VERSION 16.10.0
+ENV NPM_VERSION 7.24.0
 
 RUN apt-get update -y && \
     apt-get upgrade -y && \


### PR DESCRIPTION
This PR upgrade node & npm versions to 16 and 7 into changelog-publish orb. 

To be able to test, 
Circleci build a dev image here => changelog@dev:upgrade-node
This image will be used in different projects like ui-jobteaser and ui-kit 