### PR TITLE
feat(rb-service): Update orb for `bundle --without development test`

### DIFF
--- a/orbs/rb-service/orb.yml
+++ b/orbs/rb-service/orb.yml
@@ -40,16 +40,21 @@ commands:
 
   install_ruby_dependencies:
     parameters:
-      bundler_options:
+      bundle_without:
         type: string
-        default: ''
+        default: ""
+        description: "Passed to `bundle config set without`"
     steps:
       - restore_ruby_bundle_cache
       - run:
           name: "Install dependencies"
           command: |
             bundle config set path "vendor/bundle"
-            bundle install << parameters.bundler_options >> \
+            bundle_without_param="<< parameters.bundle_without >>"
+            if [ -n "$bundle_without_param" ]; then
+              bundle config set --local without "$bundle_without_param"
+            fi
+            bundle install \
               --retry=3 \
               --jobs=2 \
               --no-color
@@ -95,7 +100,7 @@ jobs:
       - service/configure_ssh
       - checkout
       - install_ruby_dependencies:
-          bundler_options: "--without development test"
+          bundle_without: "development test"
       - service/generate_build_info
       - docker/setup
       - docker/login

--- a/orbs/rb-service/orb.yml
+++ b/orbs/rb-service/orb.yml
@@ -37,8 +37,23 @@ commands:
       - restore_cache:
           keys:
             - $CIRCLE_PROJECT_REPONAME-v3-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-            - $CIRCLE_PROJECT_REPONAME-v3-{{ .Branch }}
-            - $CIRCLE_PROJECT_REPONAME-v3-
+
+  install_ruby_dependencies:
+    parameters:
+      bundler_options:
+        type: string
+        default: ''
+    steps:
+      - restore_ruby_bundle_cache
+      - run:
+          name: "Install dependencies"
+          command: |
+            bundle config set path "vendor/bundle"
+            bundle install << parameters.bundler_options >> \
+              --retry=3 \
+              --jobs=2 \
+              --no-color
+      - save_ruby_bundle_cache
 
 jobs:
   test:
@@ -59,20 +74,13 @@ jobs:
     steps:
       - service/configure_ssh
       - checkout
-      - restore_ruby_bundle_cache
-      - run:
-          name: "Install dependencies"
-          command: |
-            bundle config set path "vendor/bundle"
-            bundle install --retry=3 --jobs=2 --no-color
-      - save_ruby_bundle_cache
+      - install_ruby_dependencies
       - run:
           name: "Run tests"
           command: |
             <<parameters.before_test>>
             bundle exec rake test
             <<parameters.after_test>>
-      - save_ruby_bundle_cache
       - store_test_results:
           path: test-results
 
@@ -86,12 +94,8 @@ jobs:
     steps:
       - service/configure_ssh
       - checkout
-      - restore_ruby_bundle_cache
-      - run:
-          name: "Install dependencies"
-          command: |
-            bundle config set path "vendor/bundle"
-            bundle install --retry=3 --jobs=2 --no-color
+      - install_ruby_dependencies:
+          bundler_options: "--without development test"
       - service/generate_build_info
       - docker/setup
       - docker/login


### PR DESCRIPTION
There is no need to install `development` & `test` dependency on
the production docker image.

Update the `rb-service` orb with a `install_ruby_dependencies` command
with a new parameter `bundler_options` and when building the docker
image we use `--without development test`

[OP-1330]

[OP-1330]: https://jobteaser.atlassian.net/browse/OP-1330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ