### PR TITLE
chore(node-16): update orb to node 16

### DIFF
--- a/orbs/changelog/orb.yml
+++ b/orbs/changelog/orb.yml
@@ -6,7 +6,7 @@ description: |
 executors:
   default:
     docker:
-      - image: "jobteaser/circleci-changelog-publish:1.0.0"
+      - image: "jobteaser/circleci-changelog-publish:2.0.0"
         auth:
           username: "$DOCKER_LOGIN"
           password: "$DOCKER_PASSWORD"


### PR DESCRIPTION
## Description

This PR update the "changelog" orb to use docker image node 16.

## Functional review

This new version of the orb has been tested here: https://app.circleci.com/pipelines/github/jobteaser/ui-jobteaser/12759/workflows/feb2fa37-b3f4-466b-87a0-7dcf92cdfb4c