### PR TITLE
Add job to report workflows on hold for more than a day

### DIFF
--- a/orbs/circleci/Dockerfile.concurrent
+++ b/orbs/circleci/Dockerfile.concurrent
@@ -7,6 +7,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 COPY circle-wait-job /bin/circle-wait-job
 COPY deployable /bin/deployable
+COPY report-hold /bin/report-hold
 
 RUN apt-get update -y && \
     apt-get upgrade -y && \

--- a/orbs/circleci/Dockerfile.concurrent
+++ b/orbs/circleci/Dockerfile.concurrent
@@ -7,7 +7,6 @@ ENV DEBIAN_FRONTEND noninteractive
 
 COPY circle-wait-job /bin/circle-wait-job
 COPY deployable /bin/deployable
-COPY report-hold /bin/report-hold
 
 RUN apt-get update -y && \
     apt-get upgrade -y && \

--- a/orbs/circleci/orb.yml
+++ b/orbs/circleci/orb.yml
@@ -10,6 +10,9 @@ executors:
         auth:
           username: "$DOCKER_LOGIN"
           password: "$DOCKER_PASSWORD"
+  ruby:
+    docker:
+      - image: "ruby:3.0-alpine"
 
 commands:
   wait_on_concurrent_job:
@@ -77,7 +80,7 @@ jobs:
   report_hold:
     description: >
       A job to run in cron to send a Slack notif if a workflow is on hold for too long
-    executor: "concurrent"
+    executor: "ruby"
     parameters:
       project_slug:
         description: "Slug of the target CircleCI Project to check for workflows on hold."

--- a/orbs/circleci/orb.yml
+++ b/orbs/circleci/orb.yml
@@ -6,7 +6,7 @@ description: |
 executors:
   concurrent:
     docker:
-      - image: "jobteaser/circleci-circleci-concurrent:0.0.11"
+      - image: "jobteaser/circleci-circleci-concurrent:0.0.12"
         auth:
           username: "$DOCKER_LOGIN"
           password: "$DOCKER_PASSWORD"

--- a/orbs/circleci/orb.yml
+++ b/orbs/circleci/orb.yml
@@ -10,9 +10,6 @@ executors:
         auth:
           username: "$DOCKER_LOGIN"
           password: "$DOCKER_PASSWORD"
-  ruby:
-    docker:
-      - image: "ruby:3.0-alpine"
 
 commands:
   wait_on_concurrent_job:
@@ -80,7 +77,7 @@ jobs:
   report_hold:
     description: >
       A job to run in cron to send a Slack notif if a workflow is on hold for too long
-    executor: "ruby"
+    executor: "concurrent"
     parameters:
       project_slug:
         description: "Slug of the target CircleCI Project to check for workflows on hold."

--- a/orbs/circleci/orb.yml
+++ b/orbs/circleci/orb.yml
@@ -73,3 +73,32 @@ jobs:
       # "stop_if_stale" ensures that builds for code that already present on production are not deployed again
       - stop_if_stale:
           environment: <<parameters.environment>>
+
+  report_hold:
+    description: >
+      A job to run in cron to send a Slack notif if a workflow is on hold for too long
+    executor: "concurrent"
+    parameters:
+      project_slug:
+        description: "Slug of the target CircleCI Project to check for workflows on hold."
+        type: string
+        default: "jobteaser/$CIRCLE_PROJECT_REPONAME"
+      target_branch:
+        description: "Target branch to check for workflows on hold."
+        type: string
+        default: "master"
+      circle_token_env_var:
+        description: "Name of the env var where the CircleCI token lives"
+        type: env_var_name
+        default: "CIRCLE_TOKEN"
+      slack_webhook_env_var:
+        description: "Name of the env var where the Slack Webhook lives"
+        type: env_var_name
+        default: "SLACK_WEBHOOK"
+    environment:
+      SLACK_WEBHOOK: "${<<parameters.slack_webhook_env_var>>}"
+      CIRCLE_TOKEN: "${<<parameters.circle_token_env_var>>}"
+    steps:
+      - run:
+          name: "Wait for all other builds to complete"
+          command: report-hold "<<parameters.project_slug>>" "<<parameters.target_branch>>" 

--- a/orbs/circleci/report-hold
+++ b/orbs/circleci/report-hold
@@ -46,7 +46,7 @@ def post(url, params = {})
   res = http.request(req)
   raise "failed POST request to #{url}: #{res.code} #{res.body}" unless res.is_a?(Net::HTTPSuccess)
 
-  JSON.parse(res)
+  res
 end
 
 def get_branch_pipelines(pages: 3)

--- a/orbs/circleci/report-hold
+++ b/orbs/circleci/report-hold
@@ -1,0 +1,91 @@
+#!/usr/bin/env ruby
+
+require 'uri'
+require 'net/http'
+require 'json'
+require 'base64'
+require 'ostruct'
+require 'date'
+
+def usage(msg)
+  warn("\nError: #{msg}\n\n")
+  warn('Usage: CIRCLE_TOKEN=token SLACK_WEBHOOK=hook report-hold <project-slug> [<branch=master>]')
+  exit 1
+end
+
+CIRCLE_TOKEN = ENV['CIRCLE_TOKEN']
+usage('empty CIRCLE_TOKEN') if CIRCLE_TOKEN.to_s == ''
+
+SLACK_WEBHOOK = ENV['SLACK_WEBHOOK']
+usage('empty SLACK_WEBHOOKS') if SLACK_WEBHOOK.to_s == ''
+
+PROJECT_SLUG = ARGV.first
+usage('empty project slug (first arg)') if PROJECT_SLUG.to_s == ''
+
+TARGET_BRANCH = ARGV[1].to_s == '' ? 'master' : ARGV[1]
+
+def get(url, query = {})
+  uri = URI(url)
+  uri.query = URI.encode_www_form(query) if query
+  req = Net::HTTP::Get.new(uri)
+  req.basic_auth CIRCLE_TOKEN, ''
+
+  http = Net::HTTP.new(uri.host, uri.port)
+  http.use_ssl = true
+  res = http.request(req)
+  raise "failed GET request to #{url}: #{res.code} #{res.body}" unless res.is_a?(Net::HTTPSuccess)
+
+  JSON.parse(res.body)
+end
+
+def post(url, params = {})
+  uri = URI(url)
+  req = Net::HTTP::Post.new(uri, 'Content-Type' => 'application/json')
+  req.body = params.to_json if params
+
+  http = Net::HTTP.new(uri.hostname, uri.port)
+  http.use_ssl = true
+  res = http.request(req)
+  raise "failed POST request to #{url}: #{res.code} #{res.body}" unless res.is_a?(Net::HTTPSuccess)
+
+  JSON.parse(res)
+end
+
+def get_branch_pipelines(pages: 3)
+  next_page_token = ''
+  res = []
+  pages.times do
+    resp = get("https://circleci.com/api/v2/project/gh/jobteaser/#{PROJECT_SLUG}/pipeline", next_page_token: next_page_token)
+    next_page_token = resp['next_page_token']
+    res += resp['items']
+           .select { |pipeline| pipeline.dig('vcs', 'branch') == TARGET_BRANCH }
+           .compact
+    break if next_page_token.to_s == ''
+  end
+  res
+end
+
+def get_pipeline_workflows(pipeline_id)
+  resp = get("https://circleci.com/api/v2/pipeline/#{pipeline_id}/workflow")
+  resp['items']
+end
+
+def notify_slack(text)
+  post(SLACK_WEBHOOK, text: text)
+end
+
+get_branch_pipelines.each do |pipeline|
+  res = get_pipeline_workflows(pipeline['id']).each do |workflow|
+    created_at = DateTime.parse(workflow['created_at'])
+
+    if workflow['status'] == 'on_hold' && created_at < DateTime.now.prev_day
+      days = (DateTime.now - created_at).to_i
+      user = pipeline.dig('trigger', 'actor', 'login')
+      url = "https://app.circleci.com/pipelines/github/jobteaser/#{PROJECT_SLUG}?branch=#{TARGET_BRANCH}"
+      text = format('Deploy of %s by %s has been on hold for %s days, maybe do something: %s', PROJECT_SLUG, user, days, url)
+      notify_slack(text)
+      break :done
+    end
+  end
+  break if res == :done
+end

--- a/orbs/circleci/report-hold
+++ b/orbs/circleci/report-hold
@@ -3,8 +3,6 @@
 require 'uri'
 require 'net/http'
 require 'json'
-require 'base64'
-require 'ostruct'
 require 'date'
 
 def usage(msg)
@@ -54,6 +52,7 @@ end
 def get_branch_pipelines(pages: 3)
   next_page_token = ''
   res = []
+
   pages.times do
     resp = get("https://circleci.com/api/v2/project/gh/jobteaser/#{PROJECT_SLUG}/pipeline", next_page_token: next_page_token)
     next_page_token = resp['next_page_token']
@@ -62,6 +61,7 @@ def get_branch_pipelines(pages: 3)
            .compact
     break if next_page_token.to_s == ''
   end
+
   res
 end
 
@@ -83,7 +83,9 @@ get_branch_pipelines.each do |pipeline|
       user = pipeline.dig('trigger', 'actor', 'login')
       url = "https://app.circleci.com/pipelines/github/jobteaser/#{PROJECT_SLUG}?branch=#{TARGET_BRANCH}"
       text = format('Deploy of %s by %s has been on hold for %s days, maybe do something: %s', PROJECT_SLUG, user, days, url)
+
       notify_slack(text)
+
       break :done
     end
   end

--- a/orbs/circleci/report-hold
+++ b/orbs/circleci/report-hold
@@ -85,6 +85,7 @@ get_branch_pipelines.each do |pipeline|
       text = format('Deploy of %s by %s has been on hold for %s days, maybe do something: %s', PROJECT_SLUG, user, days, url)
 
       notify_slack(text)
+      $stdout.puts("Posted to Slack: #{text}")
 
       break :done
     end


### PR DESCRIPTION
[TRAIN-1220]

We've had issues in prod recently because we forgot to press the "Hold" button on a service deploy that was hence stuck in staging. When the frontend PR was deployed, things worked in staging, but not in prod.

It's not the first time we've forgotten to deploy something, so we'd like to be notified when a workflow stays on hold for too long.

Since we'll need it on several projects, we thought of making an orb directly.

It's basically a dependency-less ruby script that uses the CircleCI API to check if a workflow is on hold, and a Slack webhook to notify us.

I'm piggy-backing on the concurrent executor for convenience. I realize it's completely independent from concurrent concerns, but I'm wondering if it's worth creating and maintaining a new Docker image just for this (Ubuntu updates...). Let me know if you'd rather I create a new Docker image/executor. [EDIT: after some back-and-forth on this forth, I went back to using the concurrent image]

- [x] Push v0.0.12 of concurrent docker image

[TRAIN-1220]: https://jobteaser.atlassian.net/browse/TRAIN-1220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ