### PR TITLE
fix_docker_orb_trivy_check

### DIFF
--- a/orbs/docker/orb.yml
+++ b/orbs/docker/orb.yml
@@ -86,7 +86,7 @@ commands:
       - run:
           name: "Check the image with trivy"
           command: |
-            GITHUB_TOKEN=$TRIVY_GITHUB_TOKEN trivy \
+            GITHUB_TOKEN=$TRIVY_GITHUB_TOKEN trivy image \
               --no-progress \
               -f json \
               -o /tmp/trivy.json \


### PR DESCRIPTION
Latest version of has change the way it must be called ([it was deprecated since one year](https://github.com/aquasecurity/trivy/discussions/1515))
Will fix the deployements that fail like so : https://app.circleci.com/pipelines/github/jobteaser/mobile/1089/workflows/b0e8fb15-e69e-4c58-8f12-6c419f1ef25f/jobs/2816