### PR TITLE
feat(go-service): Modify the test job to store artifacts and test results

### DIFF
--- a/orbs/go-service/orb.yml
+++ b/orbs/go-service/orb.yml
@@ -61,10 +61,18 @@ jobs:
           command: |
             make vet
       - run:
+          name: "Create artifacts directory"
+          command: |
+            mkdir /tmp/artifacts
+      - run:
           name: "Run tests"
           command: |
             <<parameters.pre_test_command>>
             make test
+      - store_test_results:
+          path: /tmp/artifacts/
+      - store_artifacts:
+          path: /tmp/artifacts/
       - save_go_pkg_cache
 
   build:


### PR DESCRIPTION
I'm trying to use `gotestsum` instead of the standard go test command.
This will allow us to have junit reports, and other stuffs like
color highlighting for tests.
For that, I modified the existing test job to be able to store artifacts
and test results from gotestsum 
