### PR TITLE
fix docker orb trivy where db download was timing out

### DIFF
--- a/orbs/docker/orb.yml
+++ b/orbs/docker/orb.yml
@@ -84,10 +84,18 @@ commands:
         default: "git-$CIRCLE_SHA1"
     steps:
       - run:
+          name: "Update trivy DB"
+          command: |
+            GITHUB_TOKEN=$TRIVY_GITHUB_TOKEN trivy image \
+              --no-progress \
+              --download-db-only \
+              --timeout 15m
+      - run:
           name: "Check the image with trivy"
           command: |
             GITHUB_TOKEN=$TRIVY_GITHUB_TOKEN trivy image \
               --no-progress \
+              --skip-update \
               -f json \
               -o /tmp/trivy.json \
               <<parameters.image_name>>:<<parameters.image_tag>>


### PR DESCRIPTION
Trivy db download times out during the check, so I added a step to download it with a bigger timeout, then run the check.