### PR TITLE
fix(orb-echoes): use json content type in PATCH API call

### DIFF
--- a/orbs/echoes/orb.yml
+++ b/orbs/echoes/orb.yml
@@ -105,6 +105,7 @@ commands:
           command: |
             RELEASE_ID=$(node -e "console.log(require('./echoes-release.json').id)")
             curl --location --request PATCH $ECHOES_API_ENDPOINT/$RELEASE_ID \
+              --header 'Content-Type: application/json' \
               --header 'Accept: application/json' \
               --header "Authorization: Bearer ${API_KEY}" \
               --data-raw '{


### PR DESCRIPTION
This PR fixes API call to echoes used to patch a release. A header `content-type: application/json` was missing which failed the API call.