### PR TITLE
feat(github): expose command to disable / enable admin restriction when merging a branch

### DIFF
--- a/orbs/github/orb.yml
+++ b/orbs/github/orb.yml
@@ -37,3 +37,51 @@ commands:
             tag="deployment-<<parameters.environment>>-$(date -u +'%Y%m%d%H%M%S%N')"
             git tag $tag
             git push origin $tag
+
+  set_admin_merge_restriction:
+    description: "Enable or disable admin merge restriction for given repository"
+    parameters:
+      api_token:
+        description: "The github api token allowing the operation."
+        type: string
+        default: ""
+      branch:
+        description: "The branch name."
+        type: string
+        default: "master"
+      enable:
+        description: "Enable admin merge restriction with true, disable it with false."
+        type: boolean
+        default: true
+      organization:
+        description: "Github organization name."
+        type: string
+        default: ""
+      repository:
+        description: "The repository name."
+        type: string
+        default: $CIRCLE_PROJECT_REPONAME
+    steps:
+      - run:
+          name: "Set admin merge restriction"
+          command: |
+            if [ "<<parameters.enable>>" = "true" ]; then
+              http_method="POST"
+            else
+              http_method="DELETE"
+            fi
+            protection_url="https://api.github.com/repos/<<parameters.organization>>/<<parameters.repository>>/branches/<<parameters.branch>>/protection/enforce_admins"
+
+            response_code=$(curl -X $http_method \
+              -w "%{response_code}\n" --silent --output "/dev/null" \
+              -H "Content-Type: application/json" \
+              -H "Accept: application/vnd.github.v3+json" \
+              -H "User-Agent: jobteaser" \
+              -H "Authorization: token <<parameters.api_token>>" \
+              $protection_url
+            )
+
+            if [[ $response_code != 200 && $response_code != 204 ]]; then
+              echo "Failed to switch enforce_admins protection on '<<parameters.organization>>/<<parameters.repository>>/branches/<<parameters.branch>>' with $http_method."
+              exit 1
+            fi


### PR DESCRIPTION
## Description

The present PR exposes a new `command` in `github` orb to enable / disable the restriction applied on a branch of a repository, preventing an admin from merging PRs without approval of other developers:

![Capture d’écran 2022-10-26 à 17 52 39](https://user-images.githubusercontent.com/100044/198074846-748a7bb9-9a09-415d-ac19-47562f362f67.png)

This command is especially handy in CI workflows where we want to "automerge" a PR (e.g.: for translations PR) using a github API token from an admin user.

## Functional review

No functional review is expected but you can see [here](https://app.circleci.com/pipelines/github/jobteaser/ui-jobteaser/23558/workflows/f7778ef7-251a-4bf5-95e7-0ab4f745b436/jobs/83858) a workflow where the new `command` have been tested and ran successfully.