### PR TITLE
feat(docker): Download trivy db on build

### DIFF
--- a/orbs/docker/Dockerfile.build
+++ b/orbs/docker/Dockerfile.build
@@ -30,3 +30,4 @@ RUN apt-get update -y && \
       wget apt-transport-https gnupg && \
     apt-get autoremove -y && \
     apt-get clean -y
+RUN trivy image --download-db-only


### PR DESCRIPTION
Download Trivy DB for it to not be downloaded during the CI (It seems to hang on it a little bit)
If it works, we would have to auto build the image on dockerhub every ~ 6 hours 
This would gain 2 minutes on builds where trivy is used
Dockerfile change + trivy command tested in local