### PR TITLE
feat(helm-runner): Customize checkout for deploy stages

### DIFF
--- a/orbs/helm-runner/orb.yml
+++ b/orbs/helm-runner/orb.yml
@@ -145,7 +145,14 @@ jobs:
         default: "./k8s/$CIRCLE_PROJECT_REPONAME"
     executor: "deploy"
     steps:
-      - checkout
+      - run:
+          name: "Git checkout"
+          command: |
+            git init
+            git sparse-checkout init --cone
+            git sparse-checkout set k8s/
+            git remote add origin $CIRCLE_REPOSITORY_URL
+            git pull --depth=1 origin $CIRCLE_BRANCH
       - run:
           name: "Push Helm chart to remote repo"
           command: |
@@ -241,7 +248,14 @@ jobs:
                 name: "Wait for all other builds to complete"
                 command: |
                   circle-wait-job
-      - checkout
+      - run:
+          name: "Git checkout"
+          command: |
+            git init
+            git sparse-checkout init --cone
+            git sparse-checkout set k8s/
+            git remote add origin $CIRCLE_REPOSITORY_URL
+            git pull --depth=1 origin $CIRCLE_BRANCH
       - run:
           name: "Ensure that this build is more recent than the last deployed one"
           command: |


### PR DESCRIPTION
The helm-runner orb only requires to checkout the k8s/ directory to apply configurations
Can win **1 minute** in each monolith CI run

Reference run : https://app.circleci.com/pipelines/github/jobteaser/jobteaser/44133/workflows/58e5074e-d5d3-4af2-b916-cb6c37aa55e6
Reference job : https://app.circleci.com/pipelines/github/jobteaser/jobteaser/44133/workflows/58e5074e-d5d3-4af2-b916-cb6c37aa55e6/jobs/1101625
"Git checkout" step --> 7s (Generally takes 1 to 1,5 minute)