### PR TITLE
Update e2e web orb bypass rack attack cookie

### DIFF
--- a/doc/handbook.md
+++ b/doc/handbook.md
@@ -163,10 +163,10 @@ jobs:
         description: "The command to run in e2e_jt_tests repo"
         type: "string"
         default: "npm run chrome"
-      e2e_cookie:
+      bypass_rack_attack:
         description: "The cookie to add to bypass rate limit"
         type: "string"
-        default: $COOKIE_E2E
+        default: $BYPASS_RACK_ATTACK
     executor:
       name: "default"
       tags: << parameters.tags >>
@@ -178,13 +178,13 @@ jobs:
       - create_report_folder
       - run_e2e_test:
           command: << parameters.command >>
-          e2e_cookie: << parameters.e2e_cookie >>
+          bypass_rack_attack: << parameters.bypass_rack_attack >>
       - generate_reporting
       - slack_alerting
 ```
 
 In the example above, a job called `execute_e2e_tests` is created, with custom
-parameters `tags`, `max_instances`, `command` and `e2e_cookie`. Note that few
+parameters `tags`, `max_instances`, `command` and `bypass_rack_attack`. Note that few
 steps used (like `clone_test_suite`, `create_report_folder`, ...) are also custom
 commands present in [_orb.yml_](https://github.com/jobteaser/circleci/blob/master/orbs/e2e-web/orb.yml) file.
 
@@ -256,7 +256,7 @@ You can now call your custom commands/jobs:
           tags: "not @legacy and not @flaky and not @pending and not @browserstack and not @prod"
           max_instances: "30"
           command: FEATURE_UI=$CIRCLE_SHA1 npm run chrome
-          e2e_cookie: $COOKIE_E2E
+          bypass_rack_attack: $BYPASS_RACK_ATTACK
 ```
 
 **IMPORTANT: Do not forget to prefix your command / job with the name of your orb**

--- a/doc/handbook.md
+++ b/doc/handbook.md
@@ -163,7 +163,7 @@ jobs:
         description: "The command to run in e2e_jt_tests repo"
         type: "string"
         default: "npm run chrome"
-      bypass_rack_attack:
+      bypass_rack_attack_cookie:
         description: "The cookie to add to bypass rate limit"
         type: "string"
         default: $BYPASS_RACK_ATTACK
@@ -178,13 +178,13 @@ jobs:
       - create_report_folder
       - run_e2e_test:
           command: << parameters.command >>
-          bypass_rack_attack: << parameters.bypass_rack_attack >>
+          bypass_rack_attack_cookie: << parameters.bypass_rack_attack_cookie >>
       - generate_reporting
       - slack_alerting
 ```
 
 In the example above, a job called `execute_e2e_tests` is created, with custom
-parameters `tags`, `max_instances`, `command` and `bypass_rack_attack`. Note that few
+parameters `tags`, `max_instances`, `command` and `bypass_rack_attack_cookie`. Note that few
 steps used (like `clone_test_suite`, `create_report_folder`, ...) are also custom
 commands present in [_orb.yml_](https://github.com/jobteaser/circleci/blob/master/orbs/e2e-web/orb.yml) file.
 
@@ -256,7 +256,7 @@ You can now call your custom commands/jobs:
           tags: "not @legacy and not @flaky and not @pending and not @browserstack and not @prod"
           max_instances: "30"
           command: FEATURE_UI=$CIRCLE_SHA1 npm run chrome
-          bypass_rack_attack: $BYPASS_RACK_ATTACK
+          bypass_rack_attack_cookie: $BYPASS_RACK_ATTACK
 ```
 
 **IMPORTANT: Do not forget to prefix your command / job with the name of your orb**

--- a/orbs/e2e-web/orb.yml
+++ b/orbs/e2e-web/orb.yml
@@ -254,7 +254,7 @@ jobs:
       bypass_rack_attack_cookie:
         description: "The cookie to add to bypass rate limit"
         type: "string"
-        default: $COOKIE_E2E
+        default: $BYPASS_RACK_ATTACK
       no_rl_cloudflare_cookie:
         description: "The cookie to add to bypass rate limit of Cloudflare"
         type: "string"

--- a/orbs/e2e-web/orb.yml
+++ b/orbs/e2e-web/orb.yml
@@ -135,10 +135,10 @@ commands:
         description: "The command to run in e2e_jt_tests repo"
         type: "string"
         default: "npm run chrome"
-      e2e_cookie:
+      bypass_rack_attack_cookie:
         description: "The cookie to add to bypass rate limit"
         type: "string"
-        default: $COOKIE_E2E
+        default: $BYPASS_RACK_ATTACK
       no_rl_cloudflare_cookie:
         description: "The cookie to add to bypass rate limit of CloudFlare"
         type: "string"
@@ -183,7 +183,7 @@ commands:
                 circleci-agent step halt
                 exit 0
             fi
-            export BYPASS_RACK_ATTACK=<< parameters.e2e_cookie >>
+            export BYPASS_RACK_ATTACK=<< parameters.bypass_rack_attack_cookie >>
             export NO_RL_CLOUDFLARE=<< parameters.no_rl_cloudflare_cookie >>
             cd ${CIRCLE_WORKING_DIRECTORY/#\~/$HOME}/e2e_jt_tests/
             echo "Tags to run: $TAGS"
@@ -251,7 +251,7 @@ jobs:
         description: "The command to run in e2e_jt_tests repo"
         type: "string"
         default: "npm run chrome"
-      e2e_cookie:
+      bypass_rack_attack_cookie:
         description: "The cookie to add to bypass rate limit"
         type: "string"
         default: $COOKIE_E2E
@@ -280,7 +280,7 @@ jobs:
       - create_report_folder
       - run_e2e_test:
           command: << parameters.command >>
-          e2e_cookie: << parameters.e2e_cookie >>
+          bypass_rack_attack_cookie: << parameters.bypass_rack_attack_cookie >>
           no_rl_cloudflare_cookie: << parameters.no_rl_cloudflare_cookie >>
           tags: << parameters.tags >>
           find_suites_tags_script_path: << parameters.find_suites_tags_script_path >>


### PR DESCRIPTION
e2e_cookie parameter has been replaced by bypass_rack_attack_cookie parameter to be more explicit.
Constant variable $COOKIE_E2E replaced by $BYPASS_RACK_ATTACK.

Now we are using context e2e when executing e2e tests.