### PR TITLE
doc(k8s): Update docs relative to k8s certificates requirements

### DIFF
--- a/doc/bootstrap.md
+++ b/doc/bootstrap.md
@@ -40,9 +40,10 @@ curl -sSL https://raw.githubusercontent.com/jobteaser/circleci/master/utils/conf
 ```
 
 The `configure-project` script populates the CircleCI project with
-`K8S_CA_CERT_STAGING`, `K8S_CA_CERT_PROD`, `K8S_USER_TOKEN_STAGING` and
-`K8S_USER_TOKEN_PROD` environment variable. There variables are used to
-etablish an authenticated connection to the Kubernetes cluster.
+`K8S_USER_TOKEN_STAGING` and `K8S_USER_TOKEN_PROD` environment variable.
+There variables are used to etablish an authenticated connection to the
+Kubernetes cluster. Don't forget to use the right context `deploy_staging` / 
+`deploy_prod` in your CircleCI deployment job.
 
 # Checkout key
 By default CircleCI adds a default checkout key with read only permission. The

--- a/doc/bootstrap.md
+++ b/doc/bootstrap.md
@@ -41,7 +41,7 @@ curl -sSL https://raw.githubusercontent.com/jobteaser/circleci/master/utils/conf
 
 The `configure-project` script populates the CircleCI project with
 `K8S_USER_TOKEN_STAGING` and `K8S_USER_TOKEN_PROD` environment variable.
-There variables are used to etablish an authenticated connection to the
+These variables are used to establish an authenticated connection to the
 Kubernetes cluster. Don't forget to use the right context `deploy_staging` / 
 `deploy_prod` in your CircleCI deployment job.
 

--- a/doc/handbook.md
+++ b/doc/handbook.md
@@ -37,15 +37,14 @@ A new project must perform the following steps to use the CI/CD pipeline:
   already created this configuration. This should be done in a branch.
 - Add the repository to CircleCI. Do not initiate a build.
 - Add a checkout SSH key in the configuration of the CircleCI project.
+- Use the right context `deploy_staging` / `deploy_prod` in your CircleCI
+  deployment job
 - Add the following environment variables to the CircleCI project:
-  - `K8S_CA_CERT_STAGING`
-  - `K8S_CA_CERT_PROD`
   - `K8S_USER_TOKEN_STAGING`
   - `K8S_USER_TOKEN_PROD`
 
-  CircleCI will need a user token and a CA certificate to connect to staging
-  and prod Kubernetes clusters. This shell command helps you configure your
-  CircleCI.
+  CircleCI will need a user token to connect to staging and prod Kubernetes
+  clusters. This shell command helps you configure your CircleCI.
 
   Note: you can use the following commands to extract the token and
   certificate (you'll need


### PR DESCRIPTION
Remove informations related to k8s certificate and emphasise usage of CircleCI contexts.